### PR TITLE
Added new `useCallingContext` configuration boolean

### DIFF
--- a/aedile-core/build.gradle.kts
+++ b/aedile-core/build.gradle.kts
@@ -1,3 +1,7 @@
+plugins {
+   `java-test-fixtures`
+}
+
 dependencies {
    api(libs.caffeine)
 }

--- a/aedile-core/src/test/kotlin/com/sksamuel/aedile/core/CacheTest.kt
+++ b/aedile-core/src/test/kotlin/com/sksamuel/aedile/core/CacheTest.kt
@@ -2,8 +2,10 @@ package com.sksamuel.aedile.core
 
 import io.kotest.assertions.throwables.shouldThrowAny
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.booleans.shouldBeTrue
 import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.withContext
 
 class CacheTest : FunSpec() {
    init {
@@ -90,6 +92,52 @@ class CacheTest : FunSpec() {
          cache.put("wibble", "wobble")
          cache.contains("wibble") shouldBe true
          cache.contains("bubble") shouldBe false
+      }
+
+      test("Cache.get should supports LocalThreadContextElements with useCallingContext = true") {
+         val cache = caffeineBuilder<String, String> {
+            useCallingContext = true
+         }.build()
+         withContext(BooleanThreadContextElement(true)) {
+            cache.get("foo") {
+               booleanThreadLocal.get().shouldBeTrue()
+               "bar"
+            } shouldBe "bar"
+         }
+      }
+
+      test("Cache.put should support LocalThreadContextElements with useCallingContext = true") {
+         val cache = caffeineBuilder<String, String> {
+            useCallingContext = true
+         }.build()
+         withContext(BooleanThreadContextElement(true)) {
+            cache.put("foo") {
+               booleanThreadLocal.get().shouldBeTrue()
+               "bar"
+            }
+            cache.getIfPresent("foo") shouldBe "bar"
+         }
+      }
+
+      test("Cache.getAll should support LocalThreadContextElements with useCallingContext = true") {
+         val cache = caffeineBuilder<String, String> {
+            useCallingContext = true
+         }.build()
+         withContext(BooleanThreadContextElement(true)) {
+            cache.put("foo") {
+               "wobble"
+            }
+            cache.put("bar") {
+               "wibble"
+            }
+            cache.put("baz") {
+               "wubble"
+            }
+            cache.getAll(listOf("foo", "bar", "baz")) {
+               booleanThreadLocal.get().shouldBeTrue()
+               mapOf("baz" to "wubble")
+            } shouldBe mapOf("foo" to "wobble", "bar" to "wibble", "baz" to "wubble")
+         }
       }
    }
 }

--- a/aedile-core/src/testFixtures/kotlin/com/sksamuel/aedile/core/BooleanThreadContextElement.kt
+++ b/aedile-core/src/testFixtures/kotlin/com/sksamuel/aedile/core/BooleanThreadContextElement.kt
@@ -1,0 +1,21 @@
+package com.sksamuel.aedile.core
+
+import kotlinx.coroutines.ThreadContextElement
+import kotlin.coroutines.CoroutineContext
+
+val booleanThreadLocal: ThreadLocal<Boolean> = ThreadLocal.withInitial { false }
+
+class BooleanThreadContextElement(private val value: Boolean): ThreadContextElement<Boolean> {
+    companion object Key : CoroutineContext.Key<BooleanThreadContextElement>
+    override val key : CoroutineContext.Key<BooleanThreadContextElement> = Key
+
+    override fun updateThreadContext(context: CoroutineContext): Boolean {
+        return booleanThreadLocal.get().also {
+            booleanThreadLocal.set(value)
+        }
+    }
+
+    override fun restoreThreadContext(context: CoroutineContext, oldState: Boolean) {
+        booleanThreadLocal.set(oldState)
+    }
+}


### PR DESCRIPTION
The `useCallingContext` configuration (defaulted to false) causes any functions that provide a `computer` function at the call site to add the caller's `coroutineContext` to the scope used to perform the computation.

This change means contextual information such as ThreadContextElements to not be lost when those computations are run.

This applies to both `Cache` and `LoadingCache` `compute` functions that are provided at the call site only.

In addition to this change the following was added:

* `java-test-fixtures` plugin to include a `BooleanThreadContextElement` type for unit tests
* Unit tests added for all functions that provide `compute` at the call site to verify `useCallingContext = true` preserves the calling context

Fixes #11