### PR TITLE
fix loading cache nullability

### DIFF
--- a/aedile-core/src/main/kotlin/com/sksamuel/aedile/core/LoadingCache.kt
+++ b/aedile-core/src/main/kotlin/com/sksamuel/aedile/core/LoadingCache.kt
@@ -49,8 +49,9 @@ class LoadingCache<K : Any, V>(
     *
     * See full docs at [AsyncLoadingCache.getAll].
     */
-   suspend fun getAll(keys: Collection<K>): Map<K, V> {
-      return cache.getAll(keys).await()
+   suspend fun getAll(keys: Collection<K>): Map<K, V & Any> {
+      @Suppress("UNCHECKED_CAST") // getAll returns CompletableFuture<Map<K, @NonNull V>>
+      return cache.getAll(keys).await() as Map<K, V & Any>
    }
 
    /**
@@ -65,9 +66,10 @@ class LoadingCache<K : Any, V>(
     *
     * See full docs at [AsyncCache.getAll].
     */
-   suspend fun getAll(keys: Collection<K>, compute: suspend (Set<K>) -> Map<K, V>): Map<K, V> {
+   suspend fun getAll(keys: Collection<K>, compute: suspend (Set<K>) -> Map<K, V & Any>): Map<K, V & Any> {
       val scope = CoroutineScope(coroutineContext)
-      return cache.getAll(keys) { k, _ -> scope.async { compute(k.toSet()) }.asCompletableFuture() }.await()
+      @Suppress("UNCHECKED_CAST") // getAll returns CompletableFuture<Map<K, @NonNull V>>
+      return cache.getAll(keys) { k, _ -> scope.async { compute(k.toSet()) }.asCompletableFuture() }.await() as Map<K, V & Any>
    }
 
    /**

--- a/aedile-core/src/test/kotlin/com/sksamuel/aedile/core/AsLoadingCacheTest.kt
+++ b/aedile-core/src/test/kotlin/com/sksamuel/aedile/core/AsLoadingCacheTest.kt
@@ -25,13 +25,22 @@ class AsLoadingCacheTest : FunSpec() {
          cache.get("else") shouldBe "bar"
       }
 
+      test("should support loading function returning null") {
+         val cache = Caffeine.newBuilder().asLoadingCache<String, String?> {
+            it.takeIf { "o" !in it }
+         }
+         cache.get("woz") shouldBe null
+         cache.get("waz") shouldBe "waz"
+      }
+
       test("should support suspendable bulk loading function") {
-         val cache = Caffeine.newBuilder().asBulkLoadingCache {
+         val cache = Caffeine.newBuilder().asBulkLoadingCache<String, String> {
             delay(1)
             mapOf("tweedle" to "dee", "twuddle" to "dum")
          }
          cache.get("tweedle") shouldBe "dee"
          cache.get("twuddle") shouldBe "dum"
+         cache.get("twoddle") shouldBe null
       }
 
       test("LoadingCache should support simple puts") {


### PR DESCRIPTION
Caffeine permits a loader to return null, however the recent alignment to JSpecify annotations applied the NonNull to the loader lambda return type making it impossible to provide a loader that returns null.

This attempts to fix the nullability by enforcing `& Any` only where it's required to match the JSpecify annotations.

One issue encountered was with bulk loaders, if the bulk mapping function returns a map that doesn't contain the requested key, the cache _will_ return `null` on a single `get(K)`. As such, I've ensured that `asBulkLoadingCache` returns a `LoadingCache<K, V?>`