### PR TITLE
Fix compilation errors introduced by Kotlin 2.2.20

### DIFF
--- a/aedile-core/src/main/kotlin/com/sksamuel/aedile/core/Cache.kt
+++ b/aedile-core/src/main/kotlin/com/sksamuel/aedile/core/Cache.kt
@@ -89,7 +89,8 @@ class Cache<K : Any, V : Any>(
     */
    suspend fun getOrNull(key: K, compute: suspend (K) -> V?): V? {
       val scope = CoroutineScope(coroutineContext)
-      return cache.get(key) { k, _ -> scope.async { compute(k) }.asCompletableFuture() }.await()
+      @Suppress("UNCHECKED_CAST")
+      return cache.get(key) { k, _ -> scope.async { compute(k) }.asCompletableFuture() as CompletableFuture<V> }.await()
    }
 
    /**

--- a/aedile-core/src/main/kotlin/com/sksamuel/aedile/core/Configuration.kt
+++ b/aedile-core/src/main/kotlin/com/sksamuel/aedile/core/Configuration.kt
@@ -9,7 +9,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlin.time.Duration
 
-data class Configuration<K, V>(
+data class Configuration<K : Any, V : Any>(
 
    /**
     * Sets the [CoroutineDispatcher] that is used when executing default build functions.

--- a/aedile-core/src/main/kotlin/com/sksamuel/aedile/core/LoadingCache.kt
+++ b/aedile-core/src/main/kotlin/com/sksamuel/aedile/core/LoadingCache.kt
@@ -122,7 +122,8 @@ class LoadingCache<K : Any, V>(
     */
    suspend fun getOrNull(key: K, compute: suspend (K) -> V?): V? {
       val scope = CoroutineScope(coroutineContext)
-      return cache.get(key) { k, _ -> scope.async { compute(k) }.asCompletableFuture() }.await()
+      @Suppress("UNCHECKED_CAST")
+      return cache.get(key) { k, _ -> scope.async { compute(k) }.asCompletableFuture() as CompletableFuture<V> }.await()
    }
 
    @Deprecated("Use get", ReplaceWith("get(key, compute)"))

--- a/aedile-core/src/main/kotlin/com/sksamuel/aedile/core/builders.kt
+++ b/aedile-core/src/main/kotlin/com/sksamuel/aedile/core/builders.kt
@@ -94,8 +94,8 @@ fun <K : Any, V> Caffeine<in K, in V & Any>.asLoadingCache(
          return scope.async { compute(key) }.asCompletableFuture()
       }
 
-      override fun asyncReload(key: K, oldValue: V /* & Any */, executor: Executor): CompletableFuture<out V> {
-         return scope.async { reloadCompute(key, oldValue!!) }.asCompletableFuture()
+      override fun asyncReload(key: K, oldValue: V & Any, executor: Executor): CompletableFuture<out V> {
+         return scope.async { reloadCompute(key, oldValue) }.asCompletableFuture()
       }
    }))
 }


### PR DESCRIPTION
## Summary

The Kotlin 2.2.20 upgrade (b003c26) introduced stricter type checking that caused the project to fail compilation entirely. This PR fixes all four errors:

- **`Cache.getOrNull(key, compute)` / `LoadingCache.getOrNull(key, compute)`**: `scope.async { compute(k) }` infers `Deferred<V?>` (since `compute` returns `V?`), producing `CompletableFuture<V?>` — but Caffeine's loader callback requires `CompletableFuture<out V>`. Added `@Suppress("UNCHECKED_CAST")` with an explicit cast, matching the same pattern used elsewhere in the file. The runtime behaviour is unchanged: Caffeine auto-removes the entry when the future completes with null.

- **`builders.kt` `asyncReload` override**: The override signature had `oldValue: V` with a `/* & Any */` comment as a workaround. Kotlin 2.2 now requires the intersection type to be written explicitly. Uncommenting `& Any` fixes the override and lets us drop the unsafe `!!` assertion on `oldValue`.

- **`Configuration.kt`**: `Expiry<K, V>` requires both type parameters to be non-nullable (`K : Any, V : Any`). Added the missing bounds to the `Configuration` class declaration.

## Test plan

- [x] `./gradlew :aedile-core:compileKotlin` — was failing, now succeeds
- [x] `./gradlew :aedile-core:test` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)