### PR TITLE
Fix #57: cancelling one caller no longer cancels other callers awaiting the same key

### DIFF
--- a/aedile-core/src/main/kotlin/com/sksamuel/aedile/core/Cache.kt
+++ b/aedile-core/src/main/kotlin/com/sksamuel/aedile/core/Cache.kt
@@ -3,8 +3,9 @@ package com.sksamuel.aedile.core
 import com.github.benmanes.caffeine.cache.AsyncCache
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
-import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.future.asCompletableFuture
 import kotlinx.coroutines.future.asDeferred
 import kotlinx.coroutines.future.await
@@ -53,8 +54,14 @@ class Cache<K : Any, V : Any>(
     * @return the present value, the computed value, or throws.
     *
     */
-   suspend fun get(key: K, compute: suspend (K) -> V): V = coroutineScope {
-      cache.get(key) { k, _ -> future { compute(k) } }.await()
+   suspend fun get(key: K, compute: suspend (K) -> V): V {
+      val scope = CoroutineScope(coroutineContext.minusKey(Job) + SupervisorJob())
+      // thenApply gives each caller a private CompletableFuture. Cancelling it (which
+      // CompletableFuture.await() does on coroutine cancellation) does not cancel the
+      // shared source future that Caffeine deduplicates across concurrent callers.
+      return cache.get(key) { k, _ -> scope.future { compute(k) } }
+         .thenApply { it }
+         .await()
    }
 
    /**
@@ -124,8 +131,11 @@ class Cache<K : Any, V : Any>(
       return cache.asMap().mapValues { it.value.asDeferred() }
    }
 
-   suspend fun getAll(keys: Collection<K>, compute: suspend (Collection<K>) -> Map<K, V>): Map<K, V> = coroutineScope {
-      cache.getAll(keys) { ks, _ -> future { compute(ks) } }.await()
+   suspend fun getAll(keys: Collection<K>, compute: suspend (Collection<K>) -> Map<K, V>): Map<K, V> {
+      val scope = CoroutineScope(coroutineContext.minusKey(Job) + SupervisorJob())
+      return cache.getAll(keys) { ks, _ -> scope.future { compute(ks) } }
+         .thenApply { it }
+         .await()
    }
 
    /**

--- a/aedile-core/src/main/kotlin/com/sksamuel/aedile/core/LoadingCache.kt
+++ b/aedile-core/src/main/kotlin/com/sksamuel/aedile/core/LoadingCache.kt
@@ -4,8 +4,9 @@ import com.github.benmanes.caffeine.cache.AsyncCache
 import com.github.benmanes.caffeine.cache.AsyncLoadingCache
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
-import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.future.asCompletableFuture
 import kotlinx.coroutines.future.asDeferred
 import kotlinx.coroutines.future.await
@@ -68,11 +69,13 @@ class LoadingCache<K : Any, V>(
     *
     * See full docs at [AsyncCache.getAll].
     */
-   suspend fun getAll(keys: Collection<K>, compute: suspend (Set<K>) -> Map<K, V & Any>): Map<K, V & Any> =
-      coroutineScope {
-         @Suppress("UNCHECKED_CAST") // getAll returns CompletableFuture<Map<K, @NonNull V>>
-         cache.getAll(keys) { ks, _ -> future { compute(ks) } }.await() as Map<K, V & Any>
-      }
+   suspend fun getAll(keys: Collection<K>, compute: suspend (Set<K>) -> Map<K, V & Any>): Map<K, V & Any> {
+      val scope = CoroutineScope(coroutineContext.minusKey(Job) + SupervisorJob())
+      @Suppress("UNCHECKED_CAST") // getAll returns CompletableFuture<Map<K, @NonNull V>>
+      return cache.getAll(keys) { ks, _ -> scope.future { compute(ks) } }
+         .thenApply { it }
+         .await() as Map<K, V & Any>
+   }
 
    /**
     * Returns the value associated with a key in this cache, getting that value from the
@@ -88,8 +91,11 @@ class LoadingCache<K : Any, V>(
     *
     * See full docs at [AsyncLoadingCache.get].
     */
-   suspend fun get(key: K, compute: suspend (K) -> V): V = coroutineScope {
-      cache.get(key) { k, _ -> future { compute(k) } }.await()
+   suspend fun get(key: K, compute: suspend (K) -> V): V {
+      val scope = CoroutineScope(coroutineContext.minusKey(Job) + SupervisorJob())
+      return cache.get(key) { k, _ -> scope.future { compute(k) } }
+         .thenApply { it }
+         .await()
    }
 
    /**

--- a/aedile-core/src/test/kotlin/com/sksamuel/aedile/core/AsCacheTest.kt
+++ b/aedile-core/src/test/kotlin/com/sksamuel/aedile/core/AsCacheTest.kt
@@ -6,7 +6,14 @@ import io.kotest.assertions.nondeterministic.eventually
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.async
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.Channel.Factory.UNLIMITED
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.supervisorScope
+import kotlinx.coroutines.withContext
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
@@ -187,6 +194,39 @@ class AsCacheTest : FunSpec() {
          cache.getOrNull("foo") { "bar" } shouldBe "bar"
          cache.getOrNull("foo") { error("kapow") }
          cache.getOrNull("foo") shouldBe "bar"
+      }
+
+      test("cancelling one caller should not cancel other callers sharing the same in-flight compute") {
+         val cache = Caffeine.newBuilder().asCache<String, String>()
+         val loaderStarted = Channel<Unit>(UNLIMITED)
+         val loaderCanProceed = Channel<Unit>(UNLIMITED)
+         val secondCallerReady = Channel<Unit>(UNLIMITED)
+         val job1 = Job()
+
+         supervisorScope {
+            val deferred1 = async {
+               withContext(job1) {
+                  cache.get("key") {
+                     loaderStarted.send(Unit)
+                     loaderCanProceed.receive()
+                     "value"
+                  }
+               }
+            }
+
+            val deferred2 = async {
+               loaderStarted.receive()
+               secondCallerReady.send(Unit)
+               cache.get("key") { "value" }
+            }
+
+            secondCallerReady.receive()
+            job1.cancel()
+            loaderCanProceed.send(Unit)
+
+            shouldThrow<CancellationException> { deferred1.await() }
+            deferred2.await() shouldBe "value"
+         }
       }
    }
 }


### PR DESCRIPTION
Fixes #57.

## Root cause

The bug has two independent parts that together cause the failure:

**Part 1 — compute runs in the caller's scope**

`cache.get(key) { k, _ -> future { compute(k) } }` uses `coroutineScope { }` as the receiver for `future {}`. That scope is a child of the calling coroutine's Job. When the caller is cancelled, its `coroutineScope` is cancelled, which cancels the `future {}` coroutine, which completes the shared `CompletableFuture` exceptionally — and Caffeine fans that exception out to every coroutine waiting on that key.

**Part 2 — `CompletableFuture.await()` cancels the future on coroutine cancellation**

`kotlinx-coroutines-jdk8`'s `await()` installs `invokeOnCancellation { future.cancel(false) }`. Even with an independent compute scope (Part 1 fixed alone), a cancelled caller still calls `.cancel(false)` on the **shared** Caffeine future directly via `await()`, taking down all other waiters.

## Fix

Two corresponding parts:

1. Run the compute in `CoroutineScope(coroutineContext.minusKey(Job) + SupervisorJob())` — preserves all caller context elements (dispatcher, `ThreadContextElement`, etc.) but with a Job that is not connected to any caller's lifecycle. Cancelling any caller does not cancel the compute.

2. Each caller awaits `sharedFuture.thenApply { it }` — a **private** dependent `CompletableFuture`. The Java spec guarantees that cancelling a dependent future does **not** cancel its source, so the shared compute future and all other callers' dependent futures are unaffected.

Applied to `Cache.get`, `Cache.getAll`, `LoadingCache.get(key, compute)`, and `LoadingCache.getAll(keys, compute)`.

## Test

Added `"cancelling one caller should not cancel other callers sharing the same in-flight compute"` to `AsCacheTest`, which directly reproduces the scenario from the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)